### PR TITLE
P20 112/opname

### DIFF
--- a/platform_storage_api/api.py
+++ b/platform_storage_api/api.py
@@ -83,8 +83,7 @@ class StorageHandler:
             return await self._handle_open(request)
         elif operation == StorageOperation.LISTSTATUS:
             return await self._handle_liststatus(request)
-        return aiohttp.web.Response(
-            status=aiohttp.web.HTTPMethodNotAllowed.status_code)
+        raise ValueError(f'Illegal operation: {operation}')
 
     async def _handle_open(self, request):
         # TODO (A Danshyn 04/23/18): check if exists (likely in some

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -82,7 +82,10 @@ class TestStorage:
         url = api.storage_base_url + '/path/to/file'
         params = {'op': 'CREATE'}
         async with client.get(url, params=params) as response:
-            assert response.status == 405
+            assert response.status == aiohttp.web.HTTPBadRequest.status_code
+            payload = await response.json()
+            expected_error = 'Illegal operation: CREATE'
+            assert payload['error'] == expected_error
 
     @pytest.mark.asyncio
     async def test_liststatus(self, api, client):


### PR DESCRIPTION
this PR improve the API by expoing query params as follows:
instead of
`http://hostname:1234/api/v1/storage/path/to/dir?op=LISTSTATUS`
it is possible not to just do
`http://hostname:1234/api/v1/storage/path/to/dir?liststatus`

 https://neuromation.atlassian.net/browse/P20-112

fyi @astaff 