### PR TITLE
Harmonize list-status and file-status (#41)

### DIFF
--- a/platform_storage_api/fs/local.py
+++ b/platform_storage_api/fs/local.py
@@ -36,32 +36,38 @@ class FileStatus:
     permission: Optional[str] = None
 
     @classmethod
-    def create_file_status(cls,
-                           path: PurePath,
-                           size: Optional[int] = None,
-                           modification_time: Optional[int] = None,
-                           ) -> 'FileStatus':
-        return cls(path=path,
-                   type=FileStatusType.FILE,
-                   size=size,
-                   modification_time=modification_time)
+    def create_file_status(
+        cls,
+        path: PurePath,
+        size: Optional[int] = None,
+        modification_time: Optional[int] = None,
+    ) -> "FileStatus":
+        return cls(
+            path=path,
+            type=FileStatusType.FILE,
+            size=size,
+            modification_time=modification_time,
+        )
 
     @classmethod
-    def create_dir_status(cls,
-                          path: PurePath,
-                          modification_time: Optional[int] = None,
-                          ) -> 'FileStatus':
-        return cls(path=path,
-                   type=FileStatusType.DIRECTORY,
-                   size=0,
-                   modification_time=modification_time)
+    def create_dir_status(
+        cls, path: PurePath, modification_time: Optional[int] = None
+    ) -> "FileStatus":
+        return cls(
+            path=path,
+            type=FileStatusType.DIRECTORY,
+            size=0,
+            modification_time=modification_time,
+        )
 
-    def with_permission(self, permission: str) -> 'FileStatus':
-        return FileStatus(path=self.path,
-                          type=self.type,
-                          size=self.size,
-                          modification_time=self.modification_time,
-                          permission=permission)
+    def with_permission(self, permission: str) -> "FileStatus":
+        return FileStatus(
+            path=self.path,
+            type=self.type,
+            size=self.size,
+            modification_time=self.modification_time,
+            permission=permission,
+        )
 
 
 class FileSystem(metaclass=abc.ABCMeta):
@@ -148,21 +154,20 @@ class LocalFileSystem(FileSystem):
         await self._loop.run_in_executor(self._executor, self._mkdir, path)
 
     @classmethod
-    def _create_filestatus(cls,
-                           path: PurePath,
-                           basename_only: Optional[bool] = False,
-                           ) -> 'FileStatus':
+    def _create_filestatus(
+        cls, path: PurePath, basename_only: Optional[bool] = False
+    ) -> "FileStatus":
         with Path(path) as real_path:
             stat = real_path.stat()
             mod_time = int(stat.st_mtime)  # converting float to int
             path = PurePath(path.name) if basename_only else path
             if real_path.is_dir():
-                return FileStatus.create_dir_status(path,
-                                                    modification_time=mod_time)
+                return FileStatus.create_dir_status(path, modification_time=mod_time)
             else:
                 size = stat.st_size
-                return FileStatus.create_file_status(path, size,
-                                                     modification_time=mod_time)
+                return FileStatus.create_file_status(
+                    path, size, modification_time=mod_time
+                )
 
     @classmethod
     def _scandir(cls, path: PurePath) -> List[FileStatus]:
@@ -176,18 +181,16 @@ class LocalFileSystem(FileSystem):
 
     async def liststatus(self, path: PurePath) -> List[FileStatus]:
         # TODO (A Danshyn 05/03/18): the listing size is disregarded for now
-        return await self._loop.run_in_executor(self._executor,
-                                                self._scandir,
-                                                path)
+        return await self._loop.run_in_executor(self._executor, self._scandir, path)
 
     @classmethod
     def _get_file_or_dir_status(cls, path: PurePath) -> FileStatus:
         return cls._create_filestatus(path, basename_only=False)
 
     async def get_filestatus(self, path: PurePath) -> FileStatus:
-        return await self._loop.run_in_executor(self._executor,
-                                                self._get_file_or_dir_status,
-                                                path)
+        return await self._loop.run_in_executor(
+            self._executor, self._get_file_or_dir_status, path
+        )
 
     def _remove(self, path: PurePath) -> None:
         concrete_path = Path(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,8 @@ def local_tmp_dir_path():
 
 
 def get_liststatus_dict(response_json: Dict) -> List:
-    return response_json['FileStatuses']['FileStatus']
+    return response_json["FileStatuses"]["FileStatus"]
 
 
 def get_filestatus_dict(response_json: Dict) -> Dict:
-    return response_json['FileStatus']
+    return response_json["FileStatus"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,17 +2,22 @@ import os
 import uuid
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Dict, List, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 import aiohttp
 import pytest
+from jose import jwt
 from neuro_auth_client import AuthClient, User
 from yarl import URL
 
-from platform_storage_api.api import StorageHandler, create_app
-from platform_storage_api.config import (AuthConfig, Config,
-                                         EnvironConfigFactory, ServerConfig,
-                                         StorageConfig)
+from platform_storage_api.api import create_app
+from platform_storage_api.config import (
+    AuthConfig,
+    Config,
+    EnvironConfigFactory,
+    ServerConfig,
+    StorageConfig,
+)
 from platform_storage_api.storage import Storage
 
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -7,7 +7,7 @@ import aiohttp
 import aiohttp.web
 import pytest
 
-from platform_storage_api.fs.local import FileStatus, FileStatusType
+from platform_storage_api.fs.local import FileStatusType
 
 from ..conftest import get_filestatus_dict, get_liststatus_dict
 
@@ -20,7 +20,6 @@ class TestApi:
 
 
 class TestStorage:
-
     @pytest.mark.asyncio
     async def test_put_get(self, server_url, client, regular_user_factory, api):
         user = await regular_user_factory()
@@ -63,66 +62,62 @@ class TestStorage:
     @pytest.mark.asyncio
     async def test_liststatus(self, server_url, api, client, regular_user_factory):
         user = await regular_user_factory()
-        headers = {'Authorization': 'Bearer ' + user.token}
-        dir_path = f'{user.name}/path/to'
-        dir_url = f'{server_url}/{dir_path}'
-        file_name = 'file.txt'
-        url = f'{dir_url}/{file_name}'
+        headers = {"Authorization": "Bearer " + user.token}
+        dir_path = f"{user.name}/path/to"
+        dir_url = f"{server_url}/{dir_path}"
+        file_name = "file.txt"
+        url = f"{dir_url}/{file_name}"
 
-        payload = b'test'
+        payload = b"test"
         mtime_min = int(current_time())
-        async with client.put(url, headers=headers, data=BytesIO(payload)) \
-                as response:
+        async with client.put(url, headers=headers, data=BytesIO(payload)) as response:
             assert response.status == 201
 
-        params = {'op': 'LISTSTATUS'}
-        async with client.get(dir_url, headers=headers, params=params) \
-                as response:
+        params = {"op": "LISTSTATUS"}
+        async with client.get(dir_url, headers=headers, params=params) as response:
             assert response.status == 200
             statuses = get_liststatus_dict(await response.json())
             file_status = statuses[0]
 
             assert file_status == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.FILE),
-                'length': len(payload),
-                'modificationTime': mock.ANY,
-                'permission': mock.ANY,
+                "path": mock.ANY,
+                "type": str(FileStatusType.FILE),
+                "length": len(payload),
+                "modificationTime": mock.ANY,
+                "permission": None,
             }
-            assert file_status['path'] == file_name
-            assert file_status['modificationTime'] >= mtime_min
+            assert file_status["path"] == file_name
+            assert file_status["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     async def test_liststatus_no_op_param_no_equals(
         self, server_url, api, client, regular_user_factory
     ):
         user = await regular_user_factory()
-        headers = {'Authorization': 'Bearer ' + user.token}
-        dir_path = f'{user.name}/path/to'
-        dir_url = f'{server_url}/{dir_path}'
-        file_name = 'file.txt'
-        url = f'{dir_url}/{file_name}'
-        payload = b'test'
+        headers = {"Authorization": "Bearer " + user.token}
+        dir_path = f"{user.name}/path/to"
+        dir_url = f"{server_url}/{dir_path}"
+        file_name = "file.txt"
+        url = f"{dir_url}/{file_name}"
+        payload = b"test"
 
         mtime_min = int(current_time())
-        async with client.put(url, headers=headers, data=BytesIO(payload)) \
-                as response:
+        async with client.put(url, headers=headers, data=BytesIO(payload)) as response:
             assert response.status == 201
 
-        async with client.get(dir_url + '?liststatus', headers=headers) \
-                as response:
+        async with client.get(dir_url + "?liststatus", headers=headers) as response:
             statuses = get_liststatus_dict(await response.json())
             file_status = statuses[0]
 
             assert file_status == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.FILE),
-                'length': len(payload),
-                'modificationTime': mock.ANY,
-                'permission': mock.ANY,
+                "path": mock.ANY,
+                "type": str(FileStatusType.FILE),
+                "length": len(payload),
+                "modificationTime": mock.ANY,
+                "permission": mock.ANY,
             }
-            assert file_status['path'] == file_name
-            assert file_status['modificationTime'] >= mtime_min
+            assert file_status["path"] == file_name
+            assert file_status["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     async def test_ambiguous_operations_with_op(
@@ -326,14 +321,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.FILE),
-                'length': self.len_payload,
-                'modificationTime': mock.ANY,
-                'permission': 'manage',
+                "path": mock.ANY,
+                "type": str(FileStatusType.FILE),
+                "length": self.len_payload,
+                "modificationTime": mock.ANY,
+                "permission": "manage",
             }
-            assert payload['path'].endswith(self.file1)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.file1)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
         # check that directory was created
         async with self.get_filestatus(
@@ -342,14 +337,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': 'manage',
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": "manage",
             }
-            assert payload['path'].endswith(self.dir3)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
         async with self.get_filestatus(
             alice, self.dir3_file3, server_url, client, file_owner=alice
@@ -357,14 +352,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.FILE),
-                'length': self.len_payload,
-                'modificationTime': mock.ANY,
-                'permission': 'manage',
+                "path": mock.ANY,
+                "type": str(FileStatusType.FILE),
+                "length": self.len_payload,
+                "modificationTime": mock.ANY,
+                "permission": "manage",
             }
-            assert payload['path'].endswith(self.dir3_file3)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3_file3)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     async def test_filestatus_check_non_existing_file(
@@ -374,9 +369,9 @@ class TestFileStatus:
         await self.put_file(server_url, client, alice, self.file1)
 
         # Alice gets status of non-existing 'file2.txt' -- NOT FOUND
-        async with self.get_filestatus(alice, self.file2, server_url,
-                                       client, file_owner=alice) \
-                as response:
+        async with self.get_filestatus(
+            alice, self.file2, server_url, client, file_owner=alice
+        ) as response:
             assert response.status == aiohttp.web.HTTPNotFound.status_code
 
     @pytest.mark.asyncio
@@ -386,27 +381,27 @@ class TestFileStatus:
         await self.init_test_stat(server_url, client, alice)
 
         # Bob checks status of Alice's 'file1.txt' -- NOT FOUND
-        async with self.get_filestatus(bob, self.file1, server_url,
-                                       client, file_owner=alice) \
-                as response:
+        async with self.get_filestatus(
+            bob, self.file1, server_url, client, file_owner=alice
+        ) as response:
             assert response.status == aiohttp.web.HTTPNotFound.status_code
 
         # Bob checks status of Alice's 'file2.txt' -- NOT FOUND
-        async with self.get_filestatus(bob, self.file2, server_url,
-                                       client, file_owner=alice) \
-                as response:
+        async with self.get_filestatus(
+            bob, self.file2, server_url, client, file_owner=alice
+        ) as response:
             assert response.status == aiohttp.web.HTTPNotFound.status_code
 
         # Bob checks status of Alice's 'dir3' -- NOT FOUND
-        async with self.get_filestatus(bob, self.dir3, server_url,
-                                       client, file_owner=alice) \
-                as response:
+        async with self.get_filestatus(
+            bob, self.dir3, server_url, client, file_owner=alice
+        ) as response:
             assert response.status == aiohttp.web.HTTPNotFound.status_code
 
         # Bob checks status of Alice's 'dir3/file3.txt' -- NOT FOUND
-        async with self.get_filestatus(bob, self.dir3_file3, server_url,
-                                       client, file_owner=alice) \
-                as response:
+        async with self.get_filestatus(
+            bob, self.dir3_file3, server_url, client, file_owner=alice
+        ) as response:
             assert response.status == aiohttp.web.HTTPNotFound.status_code
 
     @pytest.mark.asyncio
@@ -430,14 +425,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.FILE),
-                'length': self.len_payload,
-                'modificationTime': mock.ANY,
-                'permission': permission,
+                "path": mock.ANY,
+                "type": str(FileStatusType.FILE),
+                "length": self.len_payload,
+                "modificationTime": mock.ANY,
+                "permission": permission,
             }
-            assert payload['path'].endswith(self.file1)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.file1)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("permission", ["read", "write", "manage"])
@@ -460,13 +455,13 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': permission,
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": permission,
             }
-            assert payload['path'].endswith(self.dir3)  # relative path
+            assert payload["path"].endswith(self.dir3)  # relative path
 
         # then Bob checks status dir3/file3.txt (OK)
         async with self.get_filestatus(
@@ -475,14 +470,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.FILE),
-                'length': self.len_payload,
-                'modificationTime': mock.ANY,
-                'permission': permission,
+                "path": mock.ANY,
+                "type": str(FileStatusType.FILE),
+                "length": self.len_payload,
+                "modificationTime": mock.ANY,
+                "permission": permission,
             }
-            assert payload['path'].endswith(self.dir3_file3)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3_file3)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -509,14 +504,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': perm_parent_dir,
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": perm_parent_dir,
             }
-            assert payload['path'].endswith(self.dir3)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -542,14 +537,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': perm_dir,
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": perm_dir,
             }
-            assert payload['path'].endswith(self.dir3_dir4)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3_dir4)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
         # then Bob checks status 'dir3' (permission=list)
         async with self.get_filestatus(
@@ -558,14 +553,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': perm_parent_dir,
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": perm_parent_dir,
             }
-            assert payload['path'].endswith(self.dir3)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -591,14 +586,14 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': perm_dir,
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": perm_dir,
             }
-            assert payload['path'].endswith(self.dir3)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3)  # relative path
+            assert payload["modificationTime"] >= mtime_min
 
         # then Bob checks status 'dir3/dir4' (permission=P)
         async with self.get_filestatus(
@@ -607,11 +602,11 @@ class TestFileStatus:
             assert response.status == aiohttp.web.HTTPOk.status_code
             payload = get_filestatus_dict(await response.json())
             assert payload == {
-                'path': mock.ANY,
-                'type': str(FileStatusType.DIRECTORY),
-                'length': 0,
-                'modificationTime': mock.ANY,
-                'permission': perm_child_dir,
+                "path": mock.ANY,
+                "type": str(FileStatusType.DIRECTORY),
+                "length": 0,
+                "modificationTime": mock.ANY,
+                "permission": perm_child_dir,
             }
-            assert payload['path'].endswith(self.dir3_dir4)  # relative path
-            assert payload['modificationTime'] >= mtime_min
+            assert payload["path"].endswith(self.dir3_dir4)  # relative path
+            assert payload["modificationTime"] >= mtime_min

--- a/tests/integration/test_api_sharing_resources.py
+++ b/tests/integration/test_api_sharing_resources.py
@@ -42,12 +42,11 @@ class TestStorageListAndResourceSharing:
         headers2 = {"Authorization": "Bearer " + user2.token}
 
         # create file /path/to/file by user1
-        dir_url = f'{server_url}/{user1.name}/path/to'
-        url = dir_url + '/file'
-        payload = b'test'
+        dir_url = f"{server_url}/{user1.name}/path/to"
+        url = dir_url + "/file"
+        payload = b"test"
         min_mtime_first = int(current_time())
-        async with client.put(url, headers=headers1, data=BytesIO(payload)) \
-                as response:
+        async with client.put(url, headers=headers1, data=BytesIO(payload)) as response:
             assert response.status == 201
 
         params = {"op": "MKDIRS"}
@@ -71,21 +70,23 @@ class TestStorageListAndResourceSharing:
             statuses = get_liststatus_dict(await response.json())
             statuses = sorted(statuses, key=self.file_status_sort)
             assert statuses == [
-                {'path': 'file',
-                 'length': len(payload),
-                 'type': str(FileStatusType.FILE),
-                 'modificationTime': mock.ANY,
-                 'permission': None,
-                 },
-                {'path': 'second',
-                 'length': 0,
-                 'type': str(FileStatusType.DIRECTORY),
-                 'modificationTime': mock.ANY,
-                 'permission': None,
-                 },
+                {
+                    "path": "file",
+                    "length": len(payload),
+                    "type": str(FileStatusType.FILE),
+                    "modificationTime": mock.ANY,
+                    "permission": None,
+                },
+                {
+                    "path": "second",
+                    "length": 0,
+                    "type": str(FileStatusType.DIRECTORY),
+                    "modificationTime": mock.ANY,
+                    "permission": None,
+                },
             ]
             for status in statuses:
-                assert status['modificationTime'] >= min_mtime_first
+                assert status["modificationTime"] >= min_mtime_first
 
     @pytest.mark.asyncio
     async def test_ls_other_user_data_exclude_files(
@@ -98,12 +99,11 @@ class TestStorageListAndResourceSharing:
         headers2 = {"Authorization": "Bearer " + user2.token}
 
         # create file /path/to/file by user1
-        dir_url = f'{server_url}/{user1.name}/path/to/'
-        url = dir_url + '/file'
-        payload = b'test'
+        dir_url = f"{server_url}/{user1.name}/path/to/"
+        url = dir_url + "/file"
+        payload = b"test"
         min_mtime_first = int(current_time())
-        async with client.put(url, headers=headers1, data=BytesIO(payload)) \
-                as response:
+        async with client.put(url, headers=headers1, data=BytesIO(payload)) as response:
             assert response.status == 201
 
         params = {"op": "MKDIRS"}
@@ -128,16 +128,16 @@ class TestStorageListAndResourceSharing:
             statuses = get_liststatus_dict(await response.json())
             statuses = sorted(statuses, key=self.file_status_sort)
             assert statuses == [
-                {'path': 'first',
-                 'length': 0,
-                 'type': str(FileStatusType.DIRECTORY),
-                 'modificationTime': mock.ANY,
-                 'permission': None,
-                 },
+                {
+                    "path": "first",
+                    "length": 0,
+                    "type": str(FileStatusType.DIRECTORY),
+                    "modificationTime": mock.ANY,
+                    "permission": None,
+                }
             ]
             for status in statuses:
-                assert status['modificationTime'] >= min_mtime_first
-
+                assert status["modificationTime"] >= min_mtime_first
 
     @pytest.mark.asyncio
     async def test_liststatus_other_user_data_two_subdirs(
@@ -156,17 +156,17 @@ class TestStorageListAndResourceSharing:
         async with client.put(url, headers=headers1, data=BytesIO(payload)) as response:
             assert response.status == 201
 
-        params = {'op': 'MKDIRS'}
+        params = {"op": "MKDIRS"}
         min_mtime_second = int(current_time())
-        async with client.put(dir_url + "/first/second", headers=headers1,
-                              params=params) \
-                as response:
+        async with client.put(
+            dir_url + "/first/second", headers=headers1, params=params
+        ) as response:
             assert response.status == 201
 
         min_mtime_third = int(current_time())
-        async with client.put(dir_url + "/first/third", headers=headers1,
-                              params=params) \
-                as response:
+        async with client.put(
+            dir_url + "/first/third", headers=headers1, params=params
+        ) as response:
             assert response.status == 201
 
         async with client.put(
@@ -196,18 +196,20 @@ class TestStorageListAndResourceSharing:
             statuses = get_liststatus_dict(await response.json())
             statuses = sorted(statuses, key=self.file_status_sort)
             assert statuses == [
-                {'path': 'second',
-                 'length': 0,
-                 'type': str(FileStatusType.DIRECTORY),
-                 'modificationTime': mock.ANY,
-                 'permission': None,
-                 },
-                {'path': 'third',
-                 'length': 0,
-                 'type': str(FileStatusType.DIRECTORY),
-                 'modificationTime': mock.ANY,
-                 'permission': None,
+                {
+                    "path": "second",
+                    "length": 0,
+                    "type": str(FileStatusType.DIRECTORY),
+                    "modificationTime": mock.ANY,
+                    "permission": None,
+                },
+                {
+                    "path": "third",
+                    "length": 0,
+                    "type": str(FileStatusType.DIRECTORY),
+                    "modificationTime": mock.ANY,
+                    "permission": None,
                 },
             ]
-            assert statuses[0]['modificationTime'] >= min_mtime_second
-            assert statuses[1]['modificationTime'] >= min_mtime_third
+            assert statuses[0]["modificationTime"] >= min_mtime_second
+            assert statuses[1]["modificationTime"] >= min_mtime_third

--- a/tests/unit/test_fs_local.py
+++ b/tests/unit/test_fs_local.py
@@ -123,9 +123,13 @@ class TestLocalFileSystem:
 
         statuses = await fs.liststatus(tmp_dir_path)
         assert statuses == [
-            FileStatus(expected_path, size=0,
-                       type=FileStatusType.FILE,
-                       modification_time=expected_mtime)]
+            FileStatus(
+                expected_path,
+                size=0,
+                type=FileStatusType.FILE,
+                modification_time=expected_mtime,
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_liststatus_single_file(self, fs, tmp_dir_path, tmp_file):
@@ -141,9 +145,12 @@ class TestLocalFileSystem:
         statuses = await fs.liststatus(tmp_dir_path)
         assert statuses == [
             FileStatus(
-                expected_path, size=expected_size,
+                expected_path,
+                size=expected_size,
                 type=FileStatusType.FILE,
-                modification_time=expected_mtime)]
+                modification_time=expected_mtime,
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_liststatus_single_dir(self, fs, tmp_dir_path):
@@ -155,9 +162,13 @@ class TestLocalFileSystem:
 
         statuses = await fs.liststatus(tmp_dir_path)
         assert statuses == [
-            FileStatus(expected_path, size=0,
-                       type=FileStatusType.DIRECTORY,
-                       modification_time=expected_mtime)]
+            FileStatus(
+                expected_path,
+                size=0,
+                type=FileStatusType.DIRECTORY,
+                modification_time=expected_mtime,
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_liststatus_non_existent_dir(self, fs, tmp_dir_path):
@@ -187,9 +198,13 @@ class TestLocalFileSystem:
 
         statuses = await fs.liststatus(tmp_dir_path)
         assert statuses == [
-            FileStatus(expected_path, size=0,
-                       type=FileStatusType.DIRECTORY,
-                       modification_time=expected_mtime)]
+            FileStatus(
+                expected_path,
+                size=0,
+                type=FileStatusType.DIRECTORY,
+                modification_time=expected_mtime,
+            )
+        ]
 
         await fs.remove(path)
 
@@ -202,8 +217,8 @@ class TestLocalFileSystem:
         dir_path = tmp_dir_path / expected_path
         file_path = dir_path / "file"
         await fs.mkdir(dir_path)
-        async with fs.open(file_path, mode='wb') as f:
-            await f.write(b'test')
+        async with fs.open(file_path, mode="wb") as f:
+            await f.write(b"test")
             await f.flush()
 
         stat = os.stat(file_path)
@@ -211,9 +226,13 @@ class TestLocalFileSystem:
 
         statuses = await fs.liststatus(dir_path)
         assert statuses == [
-            FileStatus(Path('file'), size=4,
-                       type=FileStatusType.FILE,
-                       modification_time=expected_mtime)]
+            FileStatus(
+                Path("file"),
+                size=4,
+                type=FileStatusType.FILE,
+                modification_time=expected_mtime,
+            )
+        ]
 
         await fs.remove(dir_path)
 
@@ -232,9 +251,14 @@ class TestLocalFileSystem:
         expected_mtime = int(stat.st_mtime)
 
         statuses = await fs.liststatus(tmp_dir_path)
-        assert statuses == [FileStatus(expected_path, size=4,
-                                       type=FileStatusType.FILE,
-                                       modification_time=expected_mtime)]
+        assert statuses == [
+            FileStatus(
+                expected_path,
+                size=4,
+                type=FileStatusType.FILE,
+                modification_time=expected_mtime,
+            )
+        ]
 
         await fs.remove(path)
 
@@ -243,7 +267,7 @@ class TestLocalFileSystem:
 
     @pytest.mark.asyncio
     async def test_get_filestatus_file(self, fs, tmp_dir_path):
-        file_relative = Path('nested')
+        file_relative = Path("nested")
         expected_file_path = tmp_dir_path / file_relative
 
         payload = b"test"
@@ -254,16 +278,18 @@ class TestLocalFileSystem:
         expected_mtime = int(stat.st_mtime)
 
         status = await fs.get_filestatus(expected_file_path)
-        assert status == FileStatus(path=expected_file_path,
-                                    size=len(payload),
-                                    type=FileStatusType.FILE,
-                                    modification_time=expected_mtime)
+        assert status == FileStatus(
+            path=expected_file_path,
+            size=len(payload),
+            type=FileStatusType.FILE,
+            modification_time=expected_mtime,
+        )
 
         await fs.remove(expected_file_path)
 
     @pytest.mark.asyncio
     async def test_get_filestatus_dir(self, fs, tmp_dir_path):
-        file_relative = Path('nested')
+        file_relative = Path("nested")
         expected_file_path = tmp_dir_path / file_relative
 
         payload = b"test"
@@ -274,9 +300,11 @@ class TestLocalFileSystem:
         expected_mtime = int(stat.st_mtime)
 
         status = await fs.get_filestatus(tmp_dir_path)
-        assert status == FileStatus(path=tmp_dir_path,
-                                    size=0,
-                                    type=FileStatusType.DIRECTORY,
-                                    modification_time=expected_mtime)
+        assert status == FileStatus(
+            path=tmp_dir_path,
+            size=0,
+            type=FileStatusType.DIRECTORY,
+            modification_time=expected_mtime,
+        )
 
         await fs.remove(expected_file_path)


### PR DESCRIPTION
Closes #41.
Response from commands `LISTSTATUS` and `FILESTATUS` are made consistent.

The response format follows the HDFS format: 
https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Status_of_a_File.2FDirectory

-- 
Response for api command `FILESTATUS`:
```
{
    "FileStatus":
      {
       "path"  : "/a/b/c/d/e/file.txt",  // Note, HDFS lacks this field 
       "length" : 0,             //in bytes, zero for directories
        "modificationTime": 1320173277227, // UNIX EPOCH TIME in MS
        "permission" : "MANAGE", // enum{READ, WRITE, MANAGE}
        "type" : "DIRECTORY",    //enum {FILE, DIRECTORY}
      }
}
```

-- 
Response for api command `LISTSTATUS`:
```
{
  "FileStatuses":
  {
    "FileStatus":
    [
      {
       "path"  : "/a/b/c/d/e/file_1.txt", 
       "length" : 4, 
        "modificationTime": 1320173277227, 
        "permission" : "MANAGE",
        "type" : "FILE", 
      },

      {
       "path"  : "/a/b/c/d/e/dir2", 
       "length" : 0,
        "modificationTime": 1320173277227,
        "permission" : "MANAGE",
        "type" : "DIRECTORY",
      },
    ]
  }
}
```
