### PR TITLE
Fix raising HTTPNoContent indefinitely

### DIFF
--- a/platform_storage_api/api.py
+++ b/platform_storage_api/api.py
@@ -272,7 +272,7 @@ class StorageHandler:
                 {"error": "Incorrect destination"},
                 status=aiohttp.web.HTTPBadRequest.status_code,
             )
-        return aiohttp.web.HTTPNoContent()
+        raise aiohttp.web.HTTPNoContent()
 
     @classmethod
     def _convert_filestatus_to_primitive(cls, status: FileStatus):


### PR DESCRIPTION
This PR fixes storage, which raised HTTPNoContent error on all possible outcomes of the mv operation (the absence of the return statement changed expected control-flow).