### PR TITLE
fixed modification time check for dirs during renaming nested files

### DIFF
--- a/platform_storage_api/api.py
+++ b/platform_storage_api/api.py
@@ -7,11 +7,12 @@ from typing import Iterator, List, Optional
 import aiohttp.web
 from aiohttp.web_exceptions import HTTPBadRequest, HTTPUnauthorized
 from aiohttp.web_request import Request
-from aiohttp_security import check_authorized, check_permission
-from async_exit_stack import AsyncExitStack
 from neuro_auth_client import AuthClient, Permission, User
 from neuro_auth_client.client import ClientSubTreeViewRoot
 from neuro_auth_client.security import AuthScheme, setup_security
+
+from aiohttp_security import check_authorized, check_permission
+from async_exit_stack import AsyncExitStack
 
 from .config import Config
 from .fs.local import FileStatus, FileStatusPermission, LocalFileSystem

--- a/tests/unit/test_fs_local.py
+++ b/tests/unit/test_fs_local.py
@@ -388,10 +388,12 @@ class TestLocalFileSystem:
 
         statuses = set(await fs.liststatus(tmp_dir_path))
         new_subdir_status = self.statuses_get(statuses, subdir)
-        assert new_subdir_status.modification_time >= \
-            old_subdir_status.modification_time
-        assert statuses | {renaming_status} | {old_subdir_status} == \
-            old_statuses | {new_subdir_status}
+        assert (
+            new_subdir_status.modification_time >= old_subdir_status.modification_time
+        )
+        assert statuses | {renaming_status} | {old_subdir_status} == old_statuses | {
+            new_subdir_status
+        }
 
         statuses = set(await fs.liststatus(subdir_path))
         assert statuses == self.statuses_rename({renaming_status}, old_name, new_name)
@@ -591,10 +593,12 @@ class TestLocalFileSystem:
 
         statuses = set(await fs.liststatus(tmp_dir_path))
         new_subdir_status = self.statuses_get(statuses, nested_dir)
-        assert new_subdir_status.modification_time >= \
-            old_subdir_status.modification_time
-        assert statuses | {renaming_status} | {old_subdir_status} == \
-            old_statuses | {new_subdir_status}
+        assert (
+            new_subdir_status.modification_time >= old_subdir_status.modification_time
+        )
+        assert statuses | {renaming_status} | {old_subdir_status} == old_statuses | {
+            new_subdir_status
+        }
 
         statuses = set(await fs.liststatus(nested_path))
         expected_statuses = self.statuses_drop(old_statuses, nested_dir)


### PR DESCRIPTION
Fixed fs tests failing due to modification time comparision.
Fixes #62 