### PR TITLE
add helm values for HSE environment

### DIFF
--- a/deploy/README
+++ b/deploy/README
@@ -1,6 +1,23 @@
+# Deploy in HSE cluster
+
+###  _cd_ to _deploy_ folder
+``` cd deploy ```
+
+### Connect to cluster
+```gcloud container clusters get-credentials hse-cluster-01 --zone us-central1-a --project light-reality-205619```
+
+### Deploy platform-storage
+```helm --set "global.env=hse" upgrade --install platformstorageapi platformstorageapi```
+
+
+
+
+
+#Deploy in stagging and dev clusters
 
 Dev : 
 	- helm --set "global.env=dev" install platformstorageapi --name=platformstorageapi
 
 Stage : 
 	- helm --set "global.env=stage" install platformstorageapi --name=platformstorageapi
+

--- a/deploy/platformstorageapi/values.yaml
+++ b/deploy/platformstorageapi/values.yaml
@@ -2,36 +2,45 @@ NP_STORAGE_NFS_SERVER:
   _default: '10.76.126.154'
   dev: '10.76.126.154'
   staging: '10.69.59.50'
+  hse: '10.60.201.234'
 NP_STORAGE_NFS_PATH:
   _default: '/dev2premium'
   dev: '/dev2premium'
   staging: '/devpremium'
+  hse: '/hse_premium'
 IMAGE:
   _default: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
   dev: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
   staging: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
+  hse: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
 NP_STORAGE_AUTH_URL:
   _default: http://platformauthapi:8080
   dev: http://platformauthapi:8080
   staging: http://platformauthapi:8080
+  hse: http://platformauthapi:8080
 NP_STORAGE_REQUESTS_CPU:
   _default: "0.3"
   dev: "0.1"
   staging: "0.1"
+  hse: "0.1"
 NP_STORAGE_LIMITS_CPU:
   _default: "0.5"
   dev: "0.2"
   staging: "0.3"
+  hse: "0.3"
 NP_STORAGE_REQUESTS_MEMORY:
   _default: "500Mi"
   dev: "300Mi"
   staging: "400Mi"
+  hse: "400Mi"
 NP_STORAGE_LIMITS_MEMORY:
   _default: "1Gi"
   dev: "600Mi"
   staging: "800Mi"
+  hse: "800Mi"
 NP_STORAGE_REPLICAS:
   _default: "2"
   dev: "2"
   staging: "2"
+  hse: "2"
 


### PR DESCRIPTION
add helm values for HSE environment for platform-auth.
for now, manual deploy can be done - instructions athttps://github.com/neuromation/platform-storage-api/blob/manual-deploy-in-hse/deploy/README#L1 -  as HSE is a temp environment.

If is needed to add automation via cicleci - need to decide the flow - from which branch we should deploy in HSE culster