### PR TITLE
fix platformstorageapi image name in helm values

### DIFF
--- a/deploy/platformstorageapi/values.yaml
+++ b/deploy/platformstorageapi/values.yaml
@@ -9,10 +9,10 @@ NP_STORAGE_NFS_PATH:
   staging: '/devpremium'
   hse: '/hse_premium'
 IMAGE:
-  _default: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
-  dev: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
-  staging: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
-  hse: gcr.io/light-reality-205619/platformstorageapi-k8s:latest
+  _default: gcr.io/light-reality-205619/platformstorageapi:latest
+  dev: gcr.io/light-reality-205619/platformstorageapi:latest
+  staging: gcr.io/light-reality-205619/platformstorageapi:latest
+  hse: gcr.io/light-reality-205619/platformstorageapi:latest
 NP_STORAGE_AUTH_URL:
   _default: http://platformauthapi:8080
   dev: http://platformauthapi:8080


### PR DESCRIPTION
`platformstorageapi` image is build but in helm values it was `platformstorageapi-k8s` (the old version)