### PR TITLE
implement deploy in client cluster + custom secret for docker login

### DIFF
--- a/deploy/platformstorageapi/templates/platformstorageapi.gke.yml
+++ b/deploy/platformstorageapi/templates/platformstorageapi.gke.yml
@@ -41,6 +41,10 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: /var/storage
+      {{- if eq .Values.global.env "client" }}
+      imagePullSecrets:
+        - name: {{ printf "%s" (pluck .Values.global.env .Values.DOCKER_LOGIN_ARTIFACTORY_SECRET_NAME | first | default .Values.DOCKER_LOGIN_ARTIFACTORY_SECRET_NAME._default) }}
+      {{- end }}
       volumes:
         - name: storage
           nfs:

--- a/deploy/platformstorageapi/values.yaml
+++ b/deploy/platformstorageapi/values.yaml
@@ -3,44 +3,58 @@ NP_STORAGE_NFS_SERVER:
   dev: '10.76.126.154'
   staging: '10.69.59.50'
   prod: '10.47.20.74'
+  client: ""
 NP_STORAGE_NFS_PATH:
   _default: '/dev2premium'
   dev: '/dev2premium'
   staging: '/devpremium'
   prod: '/prodpremium'
+  client: ""
 IMAGE:
   _default: gcr.io/light-reality-205619/platformstorageapi:latest
   dev: gcr.io/light-reality-205619/platformstorageapi:latest
   staging: gcr.io/light-reality-205619/platformstorageapi:latest
   prod: gcr.io/production-228907/platformstorageapi:latest
+  client: ""
 NP_STORAGE_AUTH_URL:
   _default: http://platformauthapi:8080
   dev: http://platformauthapi:8080
   staging: http://platformauthapi:8080
   prod: http://platformauthapi:8080
+  client: ""
 NP_STORAGE_REQUESTS_CPU:
   _default: "0.3"
   dev: "0.1"
   staging: "0.1"
   prod: "0.1"
+  client: "0.1"
 NP_STORAGE_LIMITS_CPU:
   _default: "0.5"
   dev: "0.2"
   staging: "0.3"
   prod: "0.3"
+  client: "0.3"
 NP_STORAGE_REQUESTS_MEMORY:
   _default: "500Mi"
   dev: "300Mi"
   staging: "400Mi"
   prod: "400Mi"
+  client: "400Mi"
 NP_STORAGE_LIMITS_MEMORY:
   _default: "1Gi"
   dev: "600Mi"
   staging: "800Mi"
   prod: "800Mi"
+  client: "800Mi"
 NP_STORAGE_REPLICAS:
   _default: "2"
   dev: "2"
   staging: "1"
   prod: "2"
-
+  client: "2"
+DOCKER_LOGIN_ARTIFACTORY_SECRET_NAME:
+  _default: ""
+  dev: ""
+  staging: ""
+  prod: ""
+  client: ""


### PR DESCRIPTION
This is just to see what would be needed to implement in order to add deploy support (for helm in terraform & Artifactory private docker repository) for client cluster.

No need to merge to `master` branch