### PR TITLE
Send a file length and modification time in OPEN call.

### DIFF
--- a/platform_storage_api/api.py
+++ b/platform_storage_api/api.py
@@ -170,13 +170,16 @@ class StorageHandler:
         return self._parse_operation(request) or StorageOperation.RENAME
 
     async def _handle_open(self, request: Request, storage_path: PurePath):
-        # TODO (A Danshyn 04/23/18): check if exists (likely in some
-        # middleware)
+        try:
+            fstat = await self._storage.get_filestatus(storage_path)
+        except FileNotFoundError:
+            raise aiohttp.web.HTTPNotFound
+
         response = aiohttp.web.StreamResponse(status=200)
+        response.content_length = fstat.size
+        response.last_modified = fstat.modification_time
         await response.prepare(request)
         await self._storage.retrieve(response, storage_path)
-        assert "Content-Length" in response.headers
-        assert "Last-Modified" in response.headers
         await response.write_eof()
 
         return response

--- a/platform_storage_api/storage.py
+++ b/platform_storage_api/storage.py
@@ -34,9 +34,6 @@ class Storage:
 
     async def retrieve(self, instream, path: Union[PurePath, str]) -> None:
         real_path = self._resolve_real_path(PurePath(path))
-        filestatus = await self._fs.get_filestatus(real_path)
-        instream.content_length = filestatus.size
-        instream.last_modified = filestatus.modification_time
         async with self._fs.open(real_path, "rb") as f:
             await copy_streams(f, instream)
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -60,13 +60,8 @@ class TestStorage:
         async with local_fs.open(real_file_path, "wb") as f:
             await f.write(expected_payload)
 
-        real_stat = os.stat(str(real_file_path))
-
         instream = AsyncBytesIO()
         await storage.retrieve(instream, "/file")
-        assert instream.content_length == real_stat.st_size
-        assert instream.last_modified == int(real_stat.st_mtime)
-
         instream.seek(0)
         payload = await instream.read()
         assert payload == expected_payload


### PR DESCRIPTION
Closes #80.