### PR TITLE
Fix tests for modificationTime.

### DIFF
--- a/tests/integration/test_api_sharing_resources.py
+++ b/tests/integration/test_api_sharing_resources.py
@@ -1,3 +1,4 @@
+import asyncio
 from io import BytesIO
 from time import time as current_time
 from unittest import mock
@@ -266,18 +267,23 @@ class TestStorageListAndResourceSharing:
             assert response.status == 201
 
         params = {"op": "MKDIRS"}
+        await asyncio.sleep(1)
         min_mtime_third = int(current_time())
+        await asyncio.sleep(1)
         async with client.put(
             dir_url + "/first/second/third", headers=headers1, params=params
         ) as response:
             assert response.status == 201
 
+        await asyncio.sleep(1)
         min_mtime_fourth = int(current_time())
+        await asyncio.sleep(1)
         async with client.put(
             dir_url + "/first/second/fourth", headers=headers1, params=params
         ) as response:
             assert response.status == 201
 
+        await asyncio.sleep(1)
         async with client.put(
             dir_url + "/first/fifth", headers=headers1, params=params
         ) as response:


### PR DESCRIPTION
There were some errors in tests for `modificationTime`. In most cases tests are passed because all files and directories are created in the range of the same second (mtimes are truncated to integer seconds). But there is tiny probability of the failure. See for example: https://circleci.com/gh/neuromation/platform-storage-api/477.