### PR TITLE
Pin deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements-test.txt
-pdbpp
+pdbpp==0.10.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -e .
 pytest==5.1.1
-pytest-asyncio
-flake8
-flake8-mypy
+pytest-asyncio==0.10.0
+flake8==3.7.8
+flake8-mypy==17.8.0
 black==19.3b0


### PR DESCRIPTION
Switch to 3.7 has problems with mypy check.
I'd like to get rid of flake8-mypy plugin.
Dependency pinning is the first step in this way.