### PR TITLE
Use a lock when update an expired cache.

### DIFF
--- a/platform_storage_api/cache.py
+++ b/platform_storage_api/cache.py
@@ -92,6 +92,8 @@ class PermissionsCache(AbstractPermissionChecker):
                 tree = cached.tree
                 expired_at = cached.expired_at
                 if expired_at < now:
+                    if not stack:
+                        return None
                     try:
                         tree = await self._checker.get_user_permissions_tree(
                             request, target_path


### PR DESCRIPTION
Closes #144.