### PR TITLE
Drop transfer tracing, it is too redundant

### DIFF
--- a/platform_storage_api/fs/local.py
+++ b/platform_storage_api/fs/local.py
@@ -287,9 +287,7 @@ async def copy_streams(
     It is assumed that stream implementations would handle retries themselves.
     """
     while True:
-        async with tracing_cm("recv_chunk"):
-            chunk = await outstream.read(chunk_size)
+        chunk = await outstream.read(chunk_size)
         if not chunk:
             break
-        async with tracing_cm("send_chunk"):
-            await instream.write(chunk)
+        await instream.write(chunk)


### PR DESCRIPTION
https://console.cloud.google.com/traces/traces?project=light-reality-205619&tid=0000000000000000a7e8077d7e3e5ab5 is unreadable at all