### PR TITLE
Fix no error for non-recursive iterrmove of folder

### DIFF
--- a/platform_storage_api/api.py
+++ b/platform_storage_api/api.py
@@ -557,11 +557,14 @@ class StorageHandler:
         recursive = request.query.get("recursive", "true") == "true"
         response = web.StreamResponse()
         response.headers["Content-Type"] = "application/x-ndjson"
-        await response.prepare(request)
+        request_prepared = False
         try:
             async for remove_listing in await self._storage.iterremove(
                 storage_path, recursive=recursive
             ):
+                if not request_prepared:
+                    await response.prepare(request)
+                    request_prepared = True
                 listing_dict = {
                     "path": str(remove_listing.path),
                     "is_dir": remove_listing.is_dir,

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -685,8 +685,10 @@ class TestStorage:
             }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("use_stream_response", [False, True])
     async def test_cant_delete_folder_without_non_recursive(
         self,
+        use_stream_response: bool,
         server_url: str,
         client: aiohttp.ClientSession,
         regular_user_factory: Callable[[], User],
@@ -696,11 +698,14 @@ class TestStorage:
         headers = {"Authorization": "Bearer " + user.token}
         params_mkdir = {"op": "MKDIRS"}
         params_delete = {"recursive": "false"}
-        path_str = f"/{user.name}/new/nested/{uuid.uuid4()}"
+        path_str = f"/{user.name}/new/nested/foobar222/{uuid.uuid4()}"
         url = f"{server_url}{path_str}"
 
         async with client.put(url, headers=headers, params=params_mkdir) as response:
             assert response.status == aiohttp.web.HTTPCreated.status_code
+
+        if use_stream_response:
+            headers["Accept"] = "application/x-ndjson"
 
         async with client.delete(
             url, headers=headers, params=params_delete


### PR DESCRIPTION
Because `await response.prepare(request)` was called before we checked are we removing file or directory, the `400` response was lost.