### PR TITLE
Bump healthchecks timeout

### DIFF
--- a/deploy/platformstorageapi/templates/platformstorageapi.gke.yml
+++ b/deploy/platformstorageapi/templates/platformstorageapi.gke.yml
@@ -30,7 +30,8 @@ spec:
             path: /api/v1/ping
             port: tcp-web
           initialDelaySeconds: 10
-          periodSeconds: 5
+          timeoutSeconds: 60
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /api/v1/ping


### PR DESCRIPTION
Some time ago we were fixing problems with the platform storage API failures.
Due to high load, the service pods were:
- [OOM-killed](https://neuromation.slack.com/archives/C9Z1UBC6A/p1603215955079300?thread_ts=1602150986.065300&cid=C9Z1UBC6A)
- restarted due to [healthchecks failures](https://neuromation.slack.com/archives/C9Z1UBC6A/p1603266189080900?thread_ts=1602150986.065300&cid=C9Z1UBC6A)

That happened during the upload/download of many small files, which are located within the same dir.

To fix the problem on the `neuro-compute` cluster @zubenkoivan [increased](https://neuromation.slack.com/archives/C9Z1UBC6A/p1603266418081600?thread_ts=1602150986.065300&cid=C9Z1UBC6A) healthchecks timeouts and the number of pods, but It was not propagated to other clusters and a result, Synthesis faced that issue too.
Let's apply those changes to all clusters.
I decided not to bump the number of pods by default, since its depends on the number of cluster users, but the healthckeck problem might be caused by just a single person.