### PR TITLE
Switch platform services to seaweedfs

### DIFF
--- a/tests/k8s/admission-controller-deployment.yaml
+++ b/tests/k8s/admission-controller-deployment.yaml
@@ -35,7 +35,9 @@ spec:
           - name: NP_PLATFORM_CLUSTER_NAME
             value: "minikube"
           - name: S3_REGION
-            value: "none"
+            value: "us-east-1"
+          - name: S3_ENDPOINT_URL
+            value: "http://seaweedfs-s3.platform.svc.cluster.local:9000"
           - name: S3_BUCKET_NAME
             value: ""
           - name: SERVER_PORT

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,7 +60,8 @@ class TestConfig:
             "NP_PLATFORM_ADMIN_URL": "-",
             "NP_PLATFORM_TOKEN": "test-token",
             "NP_PLATFORM_CLUSTER_NAME": "test-cluster",
-            "S3_REGION": "test-region",
+            "S3_REGION": "us-east-1",
+            "S3_ENDPOINT_URL": "http://seaweedfs-s3.platform.svc.cluster.local:9000",
             "S3_BUCKET_NAME": "test-bucket",
             "NP_STORAGE_API_K8S_API_URL": "https://localhost:8443",
             "NP_STORAGE_ADMISSION_CONTROLLER_CERT_SECRET_NAME": "secret",
@@ -75,7 +76,11 @@ class TestConfig:
         assert config.platform.admin_url is None
         assert config.platform.token == "test-token"
         assert config.platform.cluster_name == "test-cluster"
-        assert config.s3.region == "test-region"
+        assert config.s3.region == "us-east-1"
+        assert (
+            config.s3.endpoint_url
+            == "http://seaweedfs-s3.platform.svc.cluster.local:9000"
+        )
         assert config.s3.bucket_name == "test-bucket"
 
     def test_from_environ_custom(
@@ -90,7 +95,8 @@ class TestConfig:
             "NP_PLATFORM_TOKEN": "test-token",
             "NP_PLATFORM_CLUSTER_NAME": "test-cluster",
             "NP_STORAGE_API_KEEP_ALIVE_TIMEOUT": "900",
-            "S3_REGION": "test-region",
+            "S3_REGION": "us-east-1",
+            "S3_ENDPOINT_URL": "http://seaweedfs-s3.platform.svc.cluster.local:9000",
             "S3_BUCKET_NAME": "test-bucket",
             "S3_KEY_PREFIX": "test-key-prefix",
             "NP_STORAGE_API_K8S_API_URL": "https://localhost:8443",
@@ -116,6 +122,10 @@ class TestConfig:
         assert config.platform.admin_url == URL("http://platform-admin/apis/admin/v1")
         assert config.platform.token == "test-token"
         assert config.platform.cluster_name == "test-cluster"
-        assert config.s3.region == "test-region"
+        assert config.s3.region == "us-east-1"
+        assert (
+            config.s3.endpoint_url
+            == "http://seaweedfs-s3.platform.svc.cluster.local:9000"
+        )
         assert config.s3.bucket_name == "test-bucket"
         assert config.s3.key_prefix == "test-key-prefix"


### PR DESCRIPTION
This pull request updates the configuration for S3-compatible storage used in platform monitoring, switching from MinIO to SeaweedFS S3, and updates all relevant credentials, endpoints, and regions across integration tests, unit tests, and Kubernetes manifests. These changes ensure consistency and correct connectivity for log storage in the new environment.

S3 Storage Provider Migration and Configuration Updates

_Switchover from MinIO to SeaweedFS S3:_

- Changed all S3 endpoint URLs from http://minio:9000 to http://seaweedfs-s3.platform.svc.cluster.local:9000 in integration test fixtures, Kubernetes manifests, and unit tests.